### PR TITLE
✨ face rank コマンドの整備

### DIFF
--- a/src/BotTidus/BotTidus.csproj
+++ b/src/BotTidus/BotTidus.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
     <PackageReference Include="MySql.Data" Version="9.2.0" />
     <PackageReference Include="MySql.EntityFrameworkCore" Version="9.0.0" />
+    <PackageReference Include="System.Runtime.Caching" Version="9.0.3" />
     <PackageReference Include="Traq" Version="0.3.0" />
     <PackageReference Include="Traq.Bot" Version="0.1.0" />
     <PackageReference Include="Yuh.Collections" Version="1.0.0-rc.2" />

--- a/src/BotTidus/BotTidus.csproj
+++ b/src/BotTidus/BotTidus.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
     <PackageReference Include="MySql.Data" Version="9.2.0" />
     <PackageReference Include="MySql.EntityFrameworkCore" Version="9.0.0" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="System.Runtime.Caching" Version="9.0.3" />
     <PackageReference Include="Traq" Version="0.3.0" />
     <PackageReference Include="Traq.Bot" Version="0.1.0" />

--- a/src/BotTidus/Helpers/TraqCacheHelper.cs
+++ b/src/BotTidus/Helpers/TraqCacheHelper.cs
@@ -1,20 +1,116 @@
 ﻿using Microsoft.Extensions.Caching.Memory;
+using System.Diagnostics.CodeAnalysis;
 
 namespace BotTidus.Helpers
 {
     static class TraqCacheHelper
     {
-        static readonly TimeSpan UserInfoExpiration = TimeSpan.FromMinutes(3);
+        static readonly TimeSpan UserDetailExpiration = TimeSpan.FromMinutes(3);
+        static readonly TimeSpan UserNameMappingExpiration = TimeSpan.FromDays(1);
+        static readonly TimeSpan UserAbstractExpiration = TimeSpan.FromDays(1);
+
+        const string Prop_User = "traq.user";
+        const string Prop_UsernameMapping = "traq.usernameMap";
+        const string Prop_UserAbstract = "traq.userAbstract";
+
+        static TItem Set<TKey, TItem>(this IMemoryCache cache, string prop, TKey key, TItem value, TimeSpan absoluteExpiration)
+        {
+            return cache.Set($"{prop}[{key}]", value, absoluteExpiration);
+        }
+
+        static bool TryGetValue<T>(this IMemoryCache cache, string prop, object key, out T? value)
+        {
+            return cache.TryGetValue($"{prop}[{key}]", out value);
+        }
 
         public static async ValueTask<Traq.Model.UserDetail> GetCachedUserAsync(this Traq.Api.IUserApi api, Guid id, IMemoryCache cache, CancellationToken ct)
         {
-            if (cache.TryGetValue<Traq.Model.UserDetail>($"traq.user[{id}]", out var user))
+            if (cache.TryGetValue<Traq.Model.UserDetail>(Prop_User, id, out var user) && user is not null)
             {
-                return user!;
+                return user;
             }
             user = await api.GetUserAsync(id, ct);
-            cache.CreateEntry($"traq.user[{id}]").SetValue(user).SetAbsoluteExpiration(UserInfoExpiration);
+            cache.Set(Prop_User, id, user, UserDetailExpiration);
             return user;
+        }
+
+        public static async ValueTask<UserPermanentInfo> GetCachedUserAbstractAsync(this Traq.Api.IUserApi api, Guid id, IMemoryCache cache, CancellationToken ct)
+        {
+            if (cache.TryGetValue<UserPermanentInfo>(Prop_UserAbstract, id, out var user) && user is not null)
+            {
+                return user;
+            }
+            var userDetail = await api.GetCachedUserAsync(id, cache, ct);
+            user = new UserPermanentInfo
+            {
+                Id = userDetail.Id,
+                Name = userDetail.Name,
+                IsBot = userDetail.Bot
+            };
+            cache.Set(Prop_UserAbstract, id, user, UserAbstractExpiration);
+            return user;
+        }
+
+        public static async ValueTask<Guid> GetCachedUserIdAsync(this Traq.Api.IUserApi api, string name, IMemoryCache cache, CancellationToken ct)
+        {
+            var nameLower = name.ToLower();
+            if (cache.TryGetValue<Guid>(Prop_UsernameMapping, nameLower, out var id))
+            {
+                return id;
+            }
+            var user = (await api.GetUsersAsync(null, name, ct)).Single();
+            cache.Set(Prop_UsernameMapping, nameLower, user.Id, UserNameMappingExpiration);
+            cache.Set(Prop_UsernameMapping, user.Id, nameLower, UserNameMappingExpiration);
+            return user.Id;
+        }
+
+        public static async ValueTask<string> GetCachedUserNameAsync(this Traq.Api.IUserApi api, Guid id, IMemoryCache cache, CancellationToken ct)
+        {
+            if (!cache.TryGetValue<UserPermanentInfo>(Prop_UserAbstract, id, out var user) || user is null)
+            {
+                if (cache.TryGetValue<string>(Prop_UsernameMapping, id, out var name))
+                {
+                    return name!;
+                }
+                user = await api.GetCachedUserAbstractAsync(id, cache, ct);
+            }
+            var nameLower = user.Name.ToLower();
+            cache.Set(Prop_UsernameMapping, id, nameLower, UserNameMappingExpiration);
+            cache.Set(Prop_UsernameMapping, nameLower, id, UserNameMappingExpiration);
+            return user.Name;
+        }
+
+        public static ValueTask<bool> TryGetCachedUserIdAsync(this Traq.Api.IUserApi api, string name, IMemoryCache cache, out ValueTask<Guid> resultTask, CancellationToken ct)
+        {
+            if (cache.TryGetValue<Guid>(Prop_UsernameMapping, name, out var userId))
+            {
+                resultTask = ValueTask.FromResult(userId);
+                return ValueTask.FromResult(true);
+            }
+            var task = api.GetUsersAsync(null, name, ct).ContinueWith(t => t.Result.SingleOrDefault()?.Id);
+            resultTask = new(task.ContinueWith(t => t.Result.GetValueOrDefault()));
+            return new(task.ContinueWith(t =>
+            {
+                var res = t.Result;
+                if (!res.HasValue)
+                {
+                    return false;
+                }
+                var nameLower = name.ToLower();
+                cache.Set(Prop_UsernameMapping, res.Value, nameLower, UserNameMappingExpiration);
+                cache.Set(Prop_UsernameMapping, nameLower, res.Value, UserNameMappingExpiration);
+                return true;
+            }));
+        }
+
+        public sealed class UserPermanentInfo
+        {
+            public Guid Id { get; init; }
+
+            [NotNull]
+            public string? Name { get; init; }
+
+            public bool IsBot { get; init; }
         }
     }
 }

--- a/src/BotTidus/Helpers/TraqCacheHelper.cs
+++ b/src/BotTidus/Helpers/TraqCacheHelper.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.Extensions.Caching.Memory;
+
+namespace BotTidus.Helpers
+{
+    static class TraqCacheHelper
+    {
+        static readonly TimeSpan Expiration = TimeSpan.FromMinutes(3);
+
+        public static async ValueTask<Traq.Model.UserDetail> GetCachedUserAsync(this Traq.Api.IUserApi api, Guid id, IMemoryCache cache, CancellationToken ct)
+        {
+            if (cache.TryGetValue<Traq.Model.UserDetail>($"traq.user[{id}]", out var user))
+            {
+                return user!;
+            }
+            user = await api.GetUserAsync(id, ct);
+            cache.CreateEntry($"traq.user[{id}]").SetValue(user).SetAbsoluteExpiration(Expiration);
+            return user;
+        }
+    }
+}

--- a/src/BotTidus/Helpers/TraqCacheHelper.cs
+++ b/src/BotTidus/Helpers/TraqCacheHelper.cs
@@ -4,7 +4,7 @@ namespace BotTidus.Helpers
 {
     static class TraqCacheHelper
     {
-        static readonly TimeSpan Expiration = TimeSpan.FromMinutes(3);
+        static readonly TimeSpan UserInfoExpiration = TimeSpan.FromMinutes(3);
 
         public static async ValueTask<Traq.Model.UserDetail> GetCachedUserAsync(this Traq.Api.IUserApi api, Guid id, IMemoryCache cache, CancellationToken ct)
         {
@@ -13,7 +13,7 @@ namespace BotTidus.Helpers
                 return user!;
             }
             user = await api.GetUserAsync(id, ct);
-            cache.CreateEntry($"traq.user[{id}]").SetValue(user).SetAbsoluteExpiration(Expiration);
+            cache.CreateEntry($"traq.user[{id}]").SetValue(user).SetAbsoluteExpiration(UserInfoExpiration);
             return user;
         }
     }

--- a/src/BotTidus/Program.cs
+++ b/src/BotTidus/Program.cs
@@ -18,7 +18,6 @@ namespace BotTidus
             var host = Host.CreateDefaultBuilder(args)
                 .ConfigureAppConfiguration((ctx, conf) =>
                 {
-
                     var envFiles = ctx.Configuration["env-files"]?.Split(';') ?? [];
                     foreach (var envFile in envFiles)
                     {

--- a/src/BotTidus/Program.cs
+++ b/src/BotTidus/Program.cs
@@ -43,6 +43,11 @@ namespace BotTidus
                         }
                     });
 
+                    services.AddMemoryCache(o =>
+                    {
+                        o.ExpirationScanFrequency = TimeSpan.FromSeconds(30);
+                    });
+
                     services.AddDbContextFactory<RepositoryImpl.Repository>(ob =>
                     {
                         ob.UseMySQL(GetConnectionString(ctx));

--- a/src/BotTidus/Services/FaceCollector/FaceCollectingService.cs
+++ b/src/BotTidus/Services/FaceCollector/FaceCollectingService.cs
@@ -30,9 +30,9 @@ namespace BotTidus.Services.FaceCollector
                     new Domain.MessageFaceScores.MessageFaceScore(
                         m.Id,
                         m.UserId,
-                        positiveCnt,
-                        0,
                         negativeCnt,
+                        0,
+                        positiveCnt,
                         0),
                     ct);
 

--- a/src/BotTidus/Services/FaceCollector/MessageFaceCounter.cs
+++ b/src/BotTidus/Services/FaceCollector/MessageFaceCounter.cs
@@ -127,6 +127,12 @@ namespace BotTidus.Services.FaceCollector
                         result = -1;
                         goto returnResult;
                     }
+                    else if (sliced is "阿修羅")
+                    {
+                        charsUsed += 3;
+                        result = 3;
+                        goto returnResult;
+                    }
                     else if (sliced is "七面鳥")
                     {
                         charsUsed += 3;

--- a/src/BotTidus/Services/InteractiveBot/CommandHandlers/FaceCommandHandler.cs
+++ b/src/BotTidus/Services/InteractiveBot/CommandHandlers/FaceCommandHandler.cs
@@ -3,15 +3,23 @@ using BotTidus.Domain;
 using BotTidus.Domain.MessageFaceScores;
 using BotTidus.Helpers;
 using BotTidus.Services.FaceCollector;
+using Microsoft.Extensions.Caching.Memory;
 using System.Text;
 using Traq;
 using Traq.Bot.Models;
 
 namespace BotTidus.Services.InteractiveBot.CommandHandlers
 {
-    struct FaceCommandHandler(AppConfig appConfig, BotEventUser sender, IRepositoryFactory repoFactory, ITraqApiClient traq) : IAsyncConsoleCommandHandler<FaceCommandResult>
+    /*
+     * face {-h|--help}
+     * face cancel <MESSAGE>
+     * face count [{-u|--user} <USER>]
+     * face rank [-b|--include-bots] [-i|--inverse] [{-a|--all}|{-t|--take} <COUNT>]
+     */
+    struct FaceCommandHandler(AppConfig appConfig, IMemoryCache cache, BotEventUser sender, IRepositoryFactory repoFactory, ITraqApiClient traq) : IAsyncConsoleCommandHandler<FaceCommandResult>
     {
         readonly AppConfig _appConfig = appConfig;
+        readonly IMemoryCache _cache = cache;
         readonly IRepositoryFactory _repoFactory = repoFactory;
         readonly BotEventUser _sender = sender;
         readonly ITraqApiClient _traq = traq;
@@ -20,6 +28,13 @@ namespace BotTidus.Services.InteractiveBot.CommandHandlers
         string? _messageIdOrUri;
         SubCommands? _subCommand;
         string? _username;
+
+        bool _rank_all = false;
+        bool _rank_includeBots = false;
+        bool _rank_inverse = false;
+        int? _rank_take = null;
+
+        static readonly int RankTakeDefault = 10;
 
         public readonly bool RequiredArgumentsAreFilled => _subCommand is not null;
 
@@ -60,7 +75,7 @@ namespace BotTidus.Services.InteractiveBot.CommandHandlers
 
                         Options:
                             -b, --include-bots  Includes bots in the ranking.
-                            -i, --inverse       Displays the ranking in reverse order.
+                            -i, --inv           Displays the ranking in reverse order.
                         ```
                         """
                 };
@@ -75,111 +90,132 @@ namespace BotTidus.Services.InteractiveBot.CommandHandlers
                 switch (_subCommand)
                 {
                     case SubCommands.CancelMessageFaceCount:
+                    {
+                        if (_sender.Id != _appConfig.AdminUserId)
                         {
-                            if (_sender.Id != _appConfig.AdminUserId)
-                            {
-                                return new() { IsSuccessful = false, ErrorType = CommandErrorType.PermissionDenied };
-                            }
-                            if (_messageIdOrUri is null)
-                            {
-                                return new() { IsSuccessful = false, ErrorType = CommandErrorType.InvalidArguments, Message = "Message id or uri is required." };
-                            }
-
-                            Guid messageId;
-                            if (!Guid.TryParse(_messageIdOrUri, out messageId))
-                            {
-                                if (!Uri.TryCreate(_messageIdOrUri, UriKind.Absolute, out var uri)
-                                    || !Guid.TryParse(uri.AbsolutePath.Split('/').LastOrDefault(), out messageId))
-                                {
-                                    return new() { IsSuccessful = false, ErrorType = CommandErrorType.InvalidArguments, Message = $"Invalid message uri: {_messageIdOrUri}" };
-                                }
-                            }
-                            await Task.WhenAll(
-                                repo.DeleteMessageFaceScoreAsync(messageId, cancellationToken).AsTask(),
-                                _traq.StampApi.RemoveMessageStampAsync(messageId, MessageFaceCounter.PositiveReactionGuid, cancellationToken),
-                                _traq.StampApi.RemoveMessageStampAsync(messageId, MessageFaceCounter.NegativeReactionGuid, cancellationToken)
-                                );
-                            return new() { IsSuccessful = true, ReactionStampId = InteractiveBotService.StampId_Success };
+                            return new() { IsSuccessful = false, ErrorType = CommandErrorType.PermissionDenied };
                         }
-                    case SubCommands.DisplayCount:
+                        if (_messageIdOrUri is null)
                         {
-                            string username = _sender.Name;
-                            Guid userId = _sender.Id;
-                            if (_username is not null)
-                            {
-                                if (Traq.Extensions.Messages.Embedding.TryParseHead(_username.AsSpan(), out var embedding) == _username.Length)
-                                {
-                                    if (embedding.Type != Traq.Extensions.Messages.EmbeddingType.UserMention)
-                                    {
-                                        return new() { IsSuccessful = false, ErrorType = CommandErrorType.InvalidArguments, Message = "The embedding is not mentioning a user." };
-                                    }
-                                    username = embedding.DisplayText.StartsWith("@") ? embedding.DisplayText[1..].ToString() : embedding.DisplayText.ToString();
-                                    userId = embedding.EmbeddedId;
-                                }
-                                else if (await _traq.UserApi.TryGetUserIdFromNameAsync(_username, out var userTask, cancellationToken))
-                                {
-                                    username = _username;
-                                    userId = (await userTask).Id;
-                                }
-                                else
-                                {
-                                    return new() { IsSuccessful = false, ErrorType = CommandErrorType.InternalError, Message = $"User not found: {_username}" };
-                                }
-                            }
+                            return new() { IsSuccessful = false, ErrorType = CommandErrorType.InvalidArguments, Message = "Message id or uri is required." };
+                        }
 
-                            var count = await repo.GetUserFaceCountAsync(userId, cancellationToken);
-                            return new()
+                        Guid messageId;
+                        if (!Guid.TryParse(_messageIdOrUri, out messageId))
+                        {
+                            if (!Uri.TryCreate(_messageIdOrUri, UriKind.Absolute, out var uri)
+                                || !Guid.TryParse(uri.AbsolutePath.Split('/').LastOrDefault(), out messageId))
                             {
-                                IsSuccessful = true,
-                                Message = count switch
+                                return new() { IsSuccessful = false, ErrorType = CommandErrorType.InvalidArguments, Message = $"Invalid message uri: {_messageIdOrUri}" };
+                            }
+                        }
+                        await Task.WhenAll(
+                            repo.DeleteMessageFaceScoreAsync(messageId, cancellationToken).AsTask(),
+                            _traq.StampApi.RemoveMessageStampAsync(messageId, MessageFaceCounter.PositiveReactionGuid, cancellationToken),
+                            _traq.StampApi.RemoveMessageStampAsync(messageId, MessageFaceCounter.NegativeReactionGuid, cancellationToken)
+                            );
+                        return new() { IsSuccessful = true, ReactionStampId = InteractiveBotService.StampId_Success };
+                    }
+                    case SubCommands.DisplayCount:
+                    {
+                        string username = _sender.Name;
+                        Guid userId = _sender.Id;
+                        if (_username is not null)
+                        {
+                            if (Traq.Extensions.Messages.Embedding.TryParseHead(_username.AsSpan(), out var embedding) == _username.Length)
+                            {
+                                if (embedding.Type != Traq.Extensions.Messages.EmbeddingType.UserMention)
                                 {
-                                    { NegativePhraseCount: 0, NegativeReactionCount: 0, PositivePhraseCount: 0, PositiveReactionCount: 0 } => $$"""
+                                    return new() { IsSuccessful = false, ErrorType = CommandErrorType.InvalidArguments, Message = "The embedding is not mentioning a user." };
+                                }
+                                username = embedding.DisplayText.StartsWith("@") ? embedding.DisplayText[1..].ToString() : embedding.DisplayText.ToString();
+                                userId = embedding.EmbeddedId;
+                            }
+                            else if (await _traq.UserApi.TryGetUserIdFromNameAsync(_username, out var userTask, cancellationToken))
+                            {
+                                username = _username;
+                                userId = (await userTask).Id;
+                            }
+                            else
+                            {
+                                return new() { IsSuccessful = false, ErrorType = CommandErrorType.InternalError, Message = $"User not found: {_username}" };
+                            }
+                        }
+
+                        var count = await repo.GetUserFaceCountAsync(userId, cancellationToken);
+                        return new()
+                        {
+                            IsSuccessful = true,
+                            Message = count switch
+                            {
+                                { NegativePhraseCount: 0, NegativeReactionCount: 0, PositivePhraseCount: 0, PositiveReactionCount: 0 } => $$"""
                             :@{{username}}: {{username}} の現在の顔: **{{count.TotalScore}}** 個
                             顔の増減はまだないようです.
                             """,
-                                    _ => $$"""
+                                _ => $$"""
                             :@{{username}}: {{username}} の現在の顔: **{{count.TotalScore}}** 個
                             - :dotted_line_face: {{count.NegativePhraseCount + count.NegativeReactionCount}} 回
                             - :star_struck: {{count.PositivePhraseCount + count.PositiveReactionCount}} 回
                             """
-                                }
-                            };
-                        }
+                            }
+                        };
+                    }
                     case SubCommands.DisplayRanking:
+                    {
+                        if (_username is not null)
                         {
-                            if (_username is not null)
-                            {
-                                return new() { IsSuccessful = false, ErrorType = CommandErrorType.InvalidArguments };
-                            }
+                            return new() { IsSuccessful = false, ErrorType = CommandErrorType.InvalidArguments };
+                        }
 
-                            var faceCounts = await repo.GetUserFaceCountsAsync(cancellationToken);
-                            if (faceCounts.Length == 0)
-                            {
-                                return new() { IsSuccessful = true, Message = "まだ誰も顔の増減が無いようです." };
-                            }
+                        var faceCounts = await repo.GetUserFaceCountsAsync(cancellationToken);
+                        if (faceCounts.Length == 0)
+                        {
+                            return new() { IsSuccessful = true, Message = "まだ誰も顔の増減が無いようです." };
+                        }
 
+                        if (_rank_inverse)
+                        {
                             Array.Sort(faceCounts, static (a, b) => a.TotalScore - b.TotalScore);
-                            StringBuilder sb = new("""
+                        }
+                        else
+                        {
+                            Array.Sort(faceCounts, static (a, b) => b.TotalScore - a.TotalScore);
+                        }
+
+                        StringBuilder sb = new("""
                         顔ランキング
                         | 順位 | ユーザー | 現在の数 |
                         | ---: | :------ | -------: |
                         """);
-                            sb.AppendLine();
+                        sb.AppendLine();
 
-                            int rank = 1;
-                            int prevCount = int.MinValue;
-                            for (int i = 0; i < faceCounts.Length; i++)
-                            {
-                                var current = faceCounts[i];
-                                var user = await _traq.UserApi.GetUserAsync(current.UserId, cancellationToken);
-                                var count = current.TotalScore;
-                                sb.AppendLine($"| {(count == prevCount ? null : rank)} | :@{user.Name}: {user.Name} | {count} |");
-                                prevCount = count;
-                                rank++;
-                            }
 
-                            return new() { IsSuccessful = true, Message = sb.ToString() };
+                        var filteredFaceCounts = faceCounts.ToAsyncEnumerable();
+                        var cache = _cache;
+                        if (!_rank_includeBots)
+                        {
+                            var traq = _traq;
+                            filteredFaceCounts = filteredFaceCounts.WhereAwaitWithCancellation(async (x, ct) => !(await traq.UserApi.GetCachedUserAsync(x.UserId, cache, ct)).Bot);
                         }
+                        if (!_rank_all)
+                        {
+                            var takeCount = _rank_take ?? RankTakeDefault;
+                            filteredFaceCounts = filteredFaceCounts.TakeWhile((_, i) => i < takeCount);
+                        }
+
+                        int rank = 1;
+                        int prevCount = int.MinValue;
+                        await foreach (var current in filteredFaceCounts)
+                        {
+                            var user = await _traq.UserApi.GetCachedUserAsync(current.UserId, cache, cancellationToken);
+                            var count = current.TotalScore;
+                            sb.AppendLine($"| {(count == prevCount ? "-" : rank)} | :@{user.Name}: {user.Name} | {count} |");
+                            prevCount = count;
+                            rank++;
+                        }
+
+                        return new() { IsSuccessful = true, Message = sb.ToString() };
+                    }
                 }
             }
             catch (Exception ex)
@@ -232,6 +268,59 @@ namespace BotTidus.Services.InteractiveBot.CommandHandlers
                             return false;
                         }
                         _username = arg.Value.ToString();
+                    }
+                }
+            }
+            else if (_subCommand == SubCommands.DisplayRanking)
+            {
+                while (reader.NextArgument(out var arg))
+                {
+                    if (arg.HasValue)
+                    {
+                        if (arg.Name is "-t" or "--take")
+                        {
+                            if (_rank_all)
+                            {
+                                // The arguments (-t|--take) and (-a|--all) cannot be specified at the same time.
+                                return false;
+                            }
+                            if (!int.TryParse(arg.Value, out var cnt))
+                            {
+                                return false;
+                            }
+                            _rank_take = cnt;
+                        }
+                        else
+                        {
+                            return false;
+                        }
+                    }
+                    else
+                    {
+                        switch (arg.Name)
+                        {
+                            case "-a":
+                            case "--a":
+                            {
+                                if (_rank_take is not null)
+                                {
+                                    // The arguments (-t|--take) and (-a|--all) cannot be specified at the same time.
+                                    return false;
+                                }
+                                _rank_all = true;
+                                break;
+                            }
+
+                            case "-b":
+                            case "--include-bots":
+                                _rank_includeBots = true;
+                                break;
+
+                            case "-i":
+                            case "--inv":
+                                _rank_inverse = true;
+                                break;
+                        }
                     }
                 }
             }

--- a/src/BotTidus/Services/InteractiveBot/InteractiveBotService.cs
+++ b/src/BotTidus/Services/InteractiveBot/InteractiveBotService.cs
@@ -4,6 +4,7 @@ using BotTidus.Services.InteractiveBot.CommandHandlers;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using System.Diagnostics;
 using Traq;
 using Traq.Bot.Models;
 
@@ -31,8 +32,12 @@ namespace BotTidus.Services.InteractiveBot
         {
             _logger.LogDebug("Received message: {Message}", args.Message.Text);
 
+            var stopwatch = Stopwatch.StartNew();
+
             if (await TryHandleAsCommandAsync(args.Message, ct))
             {
+                stopwatch.Stop();
+                _logger.LogInformation("Executed command [{ElapsedMilliseconds}ms]: {Command}", stopwatch.ElapsedMilliseconds, args.Message.Text);
                 return;
             }
         }
@@ -129,7 +134,7 @@ namespace BotTidus.Services.InteractiveBot
                     }
                 case CommandErrorType.PermissionDenied:
                     {
-                        _logger.LogDebug("Permission denied: {CommandText} -> {Result}", message.Text, result.ToString());
+                        _logger.LogInformation("Permission denied: {CommandText} -> {Result}", message.Text, result.ToString());
                         await _traq.MessageApi.AddMessageStampAsync(message.Id, StampId_PermissionDenied, new Traq.Model.PostMessageStampRequest(1), ct);
                         break;
                     }

--- a/src/BotTidus/Services/InteractiveBot/InteractiveBotService.cs
+++ b/src/BotTidus/Services/InteractiveBot/InteractiveBotService.cs
@@ -1,6 +1,7 @@
 ﻿using BotTidus.ConsoleCommand;
 using BotTidus.Domain;
 using BotTidus.Services.InteractiveBot.CommandHandlers;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Traq;
@@ -8,9 +9,10 @@ using Traq.Bot.Models;
 
 namespace BotTidus.Services.InteractiveBot
 {
-    sealed class InteractiveBotService(IOptions<AppConfig> appConf, ILogger<InteractiveBotService> logger, IRepositoryFactory repoFactory, ITraqApiClient traq, IServiceProvider provider) : Traq.Bot.WebSocket.TraqWsBot(traq, provider)
+    sealed class InteractiveBotService(IOptions<AppConfig> appConf, IMemoryCache cache, ILogger<InteractiveBotService> logger, IRepositoryFactory repoFactory, ITraqApiClient traq, IServiceProvider provider) : Traq.Bot.WebSocket.TraqWsBot(traq, provider)
     {
         readonly AppConfig _appConf = appConf.Value;
+        readonly IMemoryCache _cache = cache;
         readonly ILogger<InteractiveBotService> _logger = logger;
         readonly IRepositoryFactory _repoFactory = repoFactory;
         readonly ITraqApiClient _traq = traq;
@@ -58,7 +60,7 @@ namespace BotTidus.Services.InteractiveBot
             {
                 case "face":
                     {
-                        if (CommandHandler.TryExecuteCommand<FaceCommandHandler, FaceCommandResult>(new(_appConf, message.Author, _repoFactory, _traq), ref reader, out var resultTask, ct))
+                        if (CommandHandler.TryExecuteCommand<FaceCommandHandler, FaceCommandResult>(new(_appConf, _cache, message.Author, _repoFactory, _traq), ref reader, out var resultTask, ct))
                         {
                             var result = await resultTask;
                             if (result.IsSuccessful)


### PR DESCRIPTION
- ✨ `/face rank` コマンドに各種オプションを追加.
  - `-a|--all`: ランキングをすべて表示.
  - `-b|--include-bots`: BOTもランキングに表示.
  - `-i|--inv`: 逆順 (少ない順) に表示.
  - `-t|--take <count>`: 上から指定された人数分のランキングを表示.
- 🐛 コマンド読み取り時のバグを修正.
- ⚡ traQ からフェッチしたデータのキャッシュを取るように.
  - 情報によって適切に寿命を設定した.