### PR TITLE
✨ 外部サービスのヘルスチェックを導入

### DIFF
--- a/src/BotTidus/Program.cs
+++ b/src/BotTidus/Program.cs
@@ -1,4 +1,5 @@
 ﻿using BotTidus.Domain;
+using BotTidus.Services.ExternalServiceHealthCheck;
 using BotTidus.Services.FaceCollector;
 using BotTidus.Services.FaceReactionCollector;
 using BotTidus.Services.HealthCheck;
@@ -53,7 +54,8 @@ namespace BotTidus
                     services.AddHealthChecks()
                         .AddTypedHostedService<FaceCollectingService>()
                         .AddTypedHostedService<FaceReactionCollectingService>()
-                        .AddTypedHostedService<StampRankingService>();
+                        .AddTypedHostedService<StampRankingService>()
+                        .AddTypedHostedService<TraqHealthCheckService>();
 
                     services.AddDbContextFactory<RepositoryImpl.Repository>(ob =>
                     {
@@ -107,6 +109,7 @@ namespace BotTidus
                     services.AddHostedService<FaceReactionCollectingService>();
                     services.AddHostedService<InteractiveBotService>();
                     services.AddHostedService<StampRankingService>();
+                    services.AddHostedService<TraqHealthCheckService>();
                 })
                 .Build();
 

--- a/src/BotTidus/Program.cs
+++ b/src/BotTidus/Program.cs
@@ -56,6 +56,7 @@ namespace BotTidus
                         .AddTypedHostedService<FaceReactionCollectingService>()
                         .AddTypedHostedService<StampRankingService>()
                         .AddTypedHostedService<TraqHealthCheckService>();
+                    services.AddSingleton<TraqHealthCheckPublisher>();
 
                     services.AddDbContextFactory<RepositoryImpl.Repository>(ob =>
                     {

--- a/src/BotTidus/Services/ExternalServiceHealthCheck/TraqHealthCheckPublisher.cs
+++ b/src/BotTidus/Services/ExternalServiceHealthCheck/TraqHealthCheckPublisher.cs
@@ -1,0 +1,9 @@
+﻿namespace BotTidus.Services.ExternalServiceHealthCheck
+{
+    internal class TraqHealthCheckPublisher()
+    {
+        public DateTimeOffset LastCheckedAt { get; internal set; }
+
+        public TraqStatus CurrentStatus { get; internal set; } = TraqStatus.Unknown;
+    }
+}

--- a/src/BotTidus/Services/ExternalServiceHealthCheck/TraqHealthCheckService.cs
+++ b/src/BotTidus/Services/ExternalServiceHealthCheck/TraqHealthCheckService.cs
@@ -1,0 +1,90 @@
+﻿using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System.Net;
+using System.Net.NetworkInformation;
+using Traq;
+
+namespace BotTidus.Services.ExternalServiceHealthCheck
+{
+    internal class TraqHealthCheckService(
+        ILogger<TraqHealthCheckService> logger,
+        ITraqApiClient traq) : BackgroundService, IHealthCheck
+    {
+        readonly Ping ping = new();
+        readonly string traqHostName = new Uri(traq.Options.BaseAddress).Host;
+
+        public DateTimeOffset LastCheckedAt { get; private set; }
+
+        public TraqStatus CurrentStatus { get; private set; } = TraqStatus.Unknown;
+
+        public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            return CurrentStatus switch
+            {
+                TraqStatus.Available => Task.FromResult(HealthCheckResult.Healthy()),
+                TraqStatus.PermissionDenied => Task.FromResult(HealthCheckResult.Degraded("The client does not have permission to access the traQ service.")),
+                TraqStatus.Unavailable => Task.FromResult(HealthCheckResult.Unhealthy("The traQ service is unavailable.")),
+                _ => Task.FromResult(HealthCheckResult.Unhealthy("The traQ service status is unknown.")),
+            };
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            using PeriodicTimer timer = new(TimeSpan.FromMinutes(1));
+            do
+            {
+                LastCheckedAt = DateTimeOffset.UtcNow;
+
+                var pingResult = await ping.SendPingAsync(traqHostName, TimeSpan.FromSeconds(5), cancellationToken: stoppingToken);
+                if (pingResult.Status is IPStatus.TimedOut or IPStatus.DestinationHostUnreachable)
+                {
+                    CurrentStatus = TraqStatus.Unavailable;
+                    continue;
+                }
+
+                try
+                {
+                    _ = await traq.MeApi.GetMeAsync(cancellationToken: stoppingToken);
+                    CurrentStatus = TraqStatus.Available;
+                }
+                catch (Exception ex)
+                {
+                    if (ex is Traq.Client.ApiException apiException)
+                    {
+                        switch (apiException.ErrorCode)
+                        {
+                            case (int)HttpStatusCode.Forbidden:
+                            case (int)HttpStatusCode.Unauthorized:
+                                CurrentStatus = TraqStatus.PermissionDenied;
+                                break;
+
+                            case (int)HttpStatusCode.ServiceUnavailable:
+                                CurrentStatus = TraqStatus.Unavailable;
+                                break;
+
+                            default:
+                                CurrentStatus = TraqStatus.Unknown;
+                                logger.LogError(ex, "Unknown response from the traQ service.");
+                                break;
+                        }
+                    }
+                    else
+                    {
+                        CurrentStatus = TraqStatus.Unknown;
+                        logger.LogError(ex, "Failed to check traQ health.");
+                    }
+                }
+            }
+            while (await timer.WaitForNextTickAsync(stoppingToken));
+        }
+    }
+
+    enum TraqStatus : byte
+    {
+        Unknown = 0,
+        Unavailable = 1,
+        PermissionDenied = 2,
+        Available = 3,
+    }
+}

--- a/src/BotTidus/Services/FaceCollector/FaceCollectingService.cs
+++ b/src/BotTidus/Services/FaceCollector/FaceCollectingService.cs
@@ -1,17 +1,22 @@
 ﻿using BotTidus.Domain;
+using BotTidus.Services.ExternalServiceHealthCheck;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using Traq.Model;
 
 namespace BotTidus.Services.FaceCollector
 {
-    internal sealed class FaceCollectingService(IOptions<AppConfig> appConf, IRepositoryFactory repoFactory, IServiceProvider services) : RecentMessageCollectingService(services, TimeSpan.FromSeconds(30)), IHealthCheck
+    internal sealed class FaceCollectingService(IOptions<AppConfig> appConf, IRepositoryFactory repoFactory, TraqHealthCheckService traqHealthCheck, IServiceProvider services) : RecentMessageCollectingService(services, TimeSpan.FromSeconds(30)), IHealthCheck
     {
         readonly AppConfig _appConf = appConf.Value;
         readonly IRepositoryFactory _repoFactory = repoFactory;
 
         public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
         {
+            if (traqHealthCheck.CurrentStatus != TraqStatus.Available)
+            {
+                return Task.FromResult(HealthCheckResult.Degraded("The traQ service is unavailable."));
+            }
             return Task.FromResult(HealthCheckResult.Healthy());
         }
 

--- a/src/BotTidus/Services/FaceCollector/FaceCollectingService.cs
+++ b/src/BotTidus/Services/FaceCollector/FaceCollectingService.cs
@@ -1,19 +1,22 @@
 ﻿using BotTidus.Domain;
+using BotTidus.Helpers;
 using BotTidus.Services.ExternalServiceHealthCheck;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using Traq.Model;
 
 namespace BotTidus.Services.FaceCollector
 {
-    internal sealed class FaceCollectingService(IOptions<AppConfig> appConf, IRepositoryFactory repoFactory, TraqHealthCheckService traqHealthCheck, IServiceProvider services) : RecentMessageCollectingService(services, TimeSpan.FromSeconds(30)), IHealthCheck
+    internal sealed class FaceCollectingService(IOptions<AppConfig> appConf, IRepositoryFactory repoFactory, IServiceProvider services) : RecentMessageCollectingService(services, TimeSpan.FromSeconds(30)), IHealthCheck
     {
         readonly AppConfig _appConf = appConf.Value;
         readonly IRepositoryFactory _repoFactory = repoFactory;
+        readonly TraqHealthCheckPublisher _traqHealthCheck = services.GetRequiredService<TraqHealthCheckPublisher>();
 
         public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
         {
-            if (traqHealthCheck.CurrentStatus != TraqStatus.Available)
+            if (_traqHealthCheck.CurrentStatus != TraqStatus.Available)
             {
                 return Task.FromResult(HealthCheckResult.Degraded("The traQ service is unavailable."));
             }

--- a/src/BotTidus/Services/RecentMessageCollectingService.cs
+++ b/src/BotTidus/Services/RecentMessageCollectingService.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using BotTidus.Services.ExternalServiceHealthCheck;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -7,6 +8,7 @@ namespace BotTidus.Services
     internal abstract class RecentMessageCollectingService(IServiceProvider services, TimeSpan interval) : BackgroundService
     {
         readonly ILogger<RecentMessageCollectingService> _logger = services.GetRequiredService<ILogger<RecentMessageCollectingService>>();
+        readonly TraqHealthCheckService _traqHealthCheck = services.GetRequiredService<TraqHealthCheckService>();
 
         protected Traq.ITraqApiClient Client { get; } = services.GetRequiredService<Traq.ITraqApiClient>();
 
@@ -21,6 +23,12 @@ namespace BotTidus.Services
 
             do
             {
+                if (_traqHealthCheck.CurrentStatus != TraqStatus.Available)
+                {
+                    _logger.LogWarning("The task is skipped because the traQ service is not available.");
+                    continue;
+                }
+
                 try
                 {
                     var timeline = await Client.ActivityApi.GetActivityTimelineAsync(limit: 50, all: true, cancellationToken: stoppingToken);

--- a/src/BotTidus/Services/RecentMessageCollectingService.cs
+++ b/src/BotTidus/Services/RecentMessageCollectingService.cs
@@ -1,4 +1,5 @@
-﻿using BotTidus.Services.ExternalServiceHealthCheck;
+﻿using BotTidus.Helpers;
+using BotTidus.Services.ExternalServiceHealthCheck;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -8,7 +9,7 @@ namespace BotTidus.Services
     internal abstract class RecentMessageCollectingService(IServiceProvider services, TimeSpan interval) : BackgroundService
     {
         readonly ILogger<RecentMessageCollectingService> _logger = services.GetRequiredService<ILogger<RecentMessageCollectingService>>();
-        readonly TraqHealthCheckService _traqHealthCheck = services.GetRequiredService<TraqHealthCheckService>();
+        readonly TraqHealthCheckPublisher _traqHealthCheck = services.GetRequiredService<TraqHealthCheckPublisher>();
 
         protected Traq.ITraqApiClient Client { get; } = services.GetRequiredService<Traq.ITraqApiClient>();
 


### PR DESCRIPTION
- traQ のヘルスチェックを導入.
  - サービスが利用不可な場合はそれを使うサービスも一時停止するように.