### PR TITLE
✨ メッセージ収集周り改善

### DIFF
--- a/src/BotTidus/AppConfig.cs
+++ b/src/BotTidus/AppConfig.cs
@@ -12,6 +12,8 @@ namespace BotTidus
         [NotNull]
         public string? BotName { get; set; }
 
+        public Guid BotId { get; set; }
+
         public Guid BotUserId { get; set; }
 
         public Guid StampRankingChannelId { get; set; }

--- a/src/BotTidus/BotTidus.csproj
+++ b/src/BotTidus/BotTidus.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="9.0.4" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
     <PackageReference Include="MySql.Data" Version="9.2.0" />
     <PackageReference Include="MySql.EntityFrameworkCore" Version="9.0.0" />

--- a/src/BotTidus/Constants/TraqStamps.cs
+++ b/src/BotTidus/Constants/TraqStamps.cs
@@ -1,0 +1,12 @@
+﻿using Stamp = (System.Guid Id, string Name);
+
+namespace BotTidus.Constants
+{
+    static class TraqStamps
+    {
+        public static readonly Stamp Clap = (Guid.Parse("027fa329-1b7c-41c3-8b80-665facbdf4aa"), "clap");
+        public static readonly Stamp OmaeoKorosu = (Guid.Parse("0190f3ca-05ef-73fa-8892-fe715141f701"), "omaeo_korosu");
+        public static readonly Stamp Otsukare = (Guid.Parse("19eb80ae-0467-4409-ad21-5dc5d0148fd6"), "otsukare");
+        public static readonly Stamp Wave = (Guid.Parse("54e37bdc-7f8d-4fe9-aaf8-6173b97d0607"), "wave");
+    }
+}

--- a/src/BotTidus/Constants/TraqUsers.cs
+++ b/src/BotTidus/Constants/TraqUsers.cs
@@ -1,0 +1,12 @@
+﻿using User = (System.Guid Id, string Name);
+
+namespace BotTidus.Constants
+{
+    static class TraqUsers
+    {
+        /// <summary>
+        /// <c>@tidus</c>: the admin of the bot.
+        /// </summary>
+        public static readonly User Tidus = (Guid.Parse("ee7d1608-6ace-46f5-835d-6a894d693af9"), "tidus");
+    }
+}

--- a/src/BotTidus/Helpers/ObjectPoolHelper.cs
+++ b/src/BotTidus/Helpers/ObjectPoolHelper.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.ObjectPool;
+using System.Linq.Expressions;
+
+namespace BotTidus.Helpers
+{
+    internal static class ObjectPoolHelper
+    {
+        public static IServiceCollection AddObjectPool<T>(this IServiceCollection services)
+            where T : class
+        {
+            services.TryAddSingleton(sp =>
+            {
+                var provider = sp.GetRequiredService<ObjectPoolProvider>();
+                return provider.Create(new PooledObjectPolicySlim<T>());
+            });
+            return services;
+        }
+    }
+
+    file sealed class PooledObjectPolicySlim<T> : IPooledObjectPolicy<T>
+        where T : class
+    {
+        static readonly Func<T> DefaultConstructor = Expression.Lambda<Func<T>>(Expression.New(typeof(T))).Compile();
+
+        public T Create() => DefaultConstructor.Invoke();
+
+        public bool Return(T obj) => true;
+    }
+}

--- a/src/BotTidus/Program.cs
+++ b/src/BotTidus/Program.cs
@@ -100,6 +100,10 @@ namespace BotTidus
                         {
                             conf.BotUserId = botUserId;
                         }
+                        if (Guid.TryParse(ctx.Configuration["BOT_ID"], out var botId))
+                        {
+                            conf.BotId = botId;
+                        }
                         if (Guid.TryParse(ctx.Configuration["STAMP_RANKING_CHANNEL_ID"], out var stampRankingChannelId))
                         {
                             conf.StampRankingChannelId = stampRankingChannelId;

--- a/src/BotTidus/Program.cs
+++ b/src/BotTidus/Program.cs
@@ -1,4 +1,5 @@
 ﻿using BotTidus.Domain;
+using BotTidus.Helpers;
 using BotTidus.Services.ExternalServiceHealthCheck;
 using BotTidus.Services.FaceCollector;
 using BotTidus.Services.FaceReactionCollector;
@@ -11,6 +12,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.ObjectPool;
 using MySql.Data.MySqlClient;
 using Traq;
 
@@ -51,6 +53,12 @@ namespace BotTidus
                     {
                         o.ExpirationScanFrequency = TimeSpan.FromSeconds(30);
                     });
+
+                    services.AddSingleton<ObjectPoolProvider, DefaultObjectPoolProvider>()
+                        .AddObjectPool<Traq.Model.PostBotActionJoinRequest>()
+                        .AddObjectPool<Traq.Model.PostBotActionLeaveRequest>()
+                        .AddObjectPool<Traq.Model.PostMessageRequest>()
+                        .AddObjectPool<Traq.Model.PostMessageStampRequest>();
 
                     services.AddHealthChecks()
                         .AddTypedHostedService<FaceCollectingService>()

--- a/src/BotTidus/Services/InteractiveBot/InteractiveBotService.cs
+++ b/src/BotTidus/Services/InteractiveBot/InteractiveBotService.cs
@@ -138,6 +138,33 @@ namespace BotTidus.Services.InteractiveBot
                     await HandleCommandError(message, await resultTask, ct);
                     return false;
                 }
+
+                case "join":
+                {
+                    if (reader.HasAnyArguments)
+                    {
+                        await HandleCommandError(message, CommonCommandResult.CreateFailed(CommandErrorType.InvalidArguments), ct);
+                        return false;
+                    }
+                    await Task.WhenAll(
+                        _traq.BotApi.LetBotJoinChannelAsync(_appConf.BotId, new Traq.Model.PostBotActionJoinRequest(message.ChannelId), ct),
+                        _traq.StampApi.AddMessageStampAsync(message.Id, StampId_Success, new Traq.Model.PostMessageStampRequest(1), ct)
+                        );
+                    return true;
+                }
+                case "leave":
+                {
+                    if (reader.HasAnyArguments)
+                    {
+                        await HandleCommandError(message, CommonCommandResult.CreateFailed(CommandErrorType.InvalidArguments), ct);
+                        return false;
+                    }
+                    await Task.WhenAll(
+                        _traq.BotApi.LetBotLeaveChannelAsync(_appConf.BotId, new Traq.Model.PostBotActionLeaveRequest(message.ChannelId), ct),
+                        _traq.StampApi.AddMessageStampAsync(message.Id, Constants.TraqStamps.Wave.Id, new Traq.Model.PostMessageStampRequest(1), ct)
+                        );
+                    return true;
+                }
             }
 
             // Unknown command
@@ -178,5 +205,14 @@ namespace BotTidus.Services.InteractiveBot
     {
         public bool IsSuccessful { get; init; }
         public CommandErrorType ErrorType { get; init; }
+
+        public static CommonCommandResult CreateFailed(CommandErrorType errorType)
+        {
+            return new CommonCommandResult
+            {
+                IsSuccessful = false,
+                ErrorType = errorType
+            };
+        }
     }
 }

--- a/src/BotTidus/Services/InteractiveBot/InteractiveBotService.cs
+++ b/src/BotTidus/Services/InteractiveBot/InteractiveBotService.cs
@@ -256,15 +256,29 @@ namespace BotTidus.Services.InteractiveBot
 
     readonly struct CommonCommandResult : ICommandResult
     {
-        public bool IsSuccessful { get; init; }
         public CommandErrorType ErrorType { get; init; }
+        public bool IsSuccessful { get; init; }
+        public string? Message { get; init; }
 
-        public static CommonCommandResult CreateFailed(CommandErrorType errorType)
+        public override string ToString()
+        {
+            if (IsSuccessful)
+            {
+                return Message ?? string.Empty;
+            }
+            else
+            {
+                return $"Error({ErrorType}): {Message ?? string.Empty}";
+            }
+        }
+
+        public static CommonCommandResult CreateFailed(CommandErrorType errorType, string? message = null)
         {
             return new CommonCommandResult
             {
+                ErrorType = errorType,
                 IsSuccessful = false,
-                ErrorType = errorType
+                Message = message
             };
         }
     }

--- a/src/BotTidus/Services/InteractiveBot/InteractiveBotService.cs
+++ b/src/BotTidus/Services/InteractiveBot/InteractiveBotService.cs
@@ -43,6 +43,13 @@ namespace BotTidus.Services.InteractiveBot
                 _logger.LogInformation("Executed command [{ElapsedMilliseconds}ms]: {Command}", stopwatch.ElapsedMilliseconds, args.Message.Text);
                 return;
             }
+            else if (MessageReactions.TryGetReaction(args.Message.Text, args.Message.Author.Id, out var reaction))
+            {
+                await Task.WhenAll(
+                    reaction.Stamp is not null ? _traq.StampApi.AddMessageStampAsync(args.Message.Id, reaction.Stamp.Value, new Traq.Model.PostMessageStampRequest(1), ct) : Task.CompletedTask,
+                    reaction.Message is not null ? _traq.MessageApi.PostMessageAsync(args.Message.ChannelId, new Traq.Model.PostMessageRequest(reaction.Message, false), ct) : Task.CompletedTask
+                    );
+            }
         }
 
         async ValueTask<bool> TryHandleAsCommandAsync(BotEventMessage message, CancellationToken ct)

--- a/src/BotTidus/Services/InteractiveBot/MessageReactions.cs
+++ b/src/BotTidus/Services/InteractiveBot/MessageReactions.cs
@@ -1,0 +1,42 @@
+﻿namespace BotTidus.Services.InteractiveBot
+{
+    static class MessageReactions
+    {
+        public static bool TryGetReaction(ReadOnlySpan<char> s, Guid sender, out Reaction reaction)
+        {
+            s = s.TrimEnd(".。、,～~ー-！!").TrimEnd();
+
+            if (s.EndsWith("しにたい") || s.EndsWith("死にたい") || s.EndsWith("ﾀﾋにたい"))
+            {
+                if (sender == Constants.TraqUsers.Tidus.Id && Random.Shared.Next(10) == 0)
+                {
+                    reaction = new Reaction($":{Constants.TraqStamps.OmaeoKorosu.Name}:", null);
+                }
+                else
+                {
+                    reaction = new Reaction("しぬな！", null);
+                }
+                return true;
+            }
+            else if ((s.EndsWith("どね") && !s.EndsWith("けどね") && !s.EndsWith("などね"))
+                || s.EndsWith(":done:"))
+            {
+                reaction = new Reaction(null, Constants.TraqStamps.Clap.Id);
+                return true;
+            }
+            else if (s.EndsWith("おわ"))
+            {
+                reaction = new Reaction(null, Constants.TraqStamps.Otsukare.Id);
+                return true;
+            }
+
+            reaction = default;
+            return false;
+        }
+
+        public readonly record struct Reaction(
+            string? Message,
+            Guid? Stamp
+            );
+    }
+}


### PR DESCRIPTION
- `join`, `leave` コマンドを追加.
- 購読中のチャンネル内で, 特定のメッセージに反応するように.
- `ObjectPool<T>` を活用して無駄なオブジェクトが増えないようになった.