### PR TITLE
🐛 最初の実行を遅らせて警告を出さないようにする

### DIFF
--- a/src/BotTidus/Services/FaceReactionCollector/FaceReactionCollectingService.cs
+++ b/src/BotTidus/Services/FaceReactionCollector/FaceReactionCollectingService.cs
@@ -20,6 +20,9 @@ namespace BotTidus.Services.FaceReactionCollector
         readonly ITraqApiClient _traq = traq;
         readonly TraqHealthCheckPublisher _traqHealthCheck = services.GetRequiredService<TraqHealthCheckPublisher>();
 
+        public TimeSpan Delay { get; } = TimeSpan.FromSeconds(15);
+        public TimeSpan Interval { get; } = TimeSpan.FromMinutes(1);
+
         public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
         {
             if (_traqHealthCheck.CurrentStatus != TraqStatus.Available)
@@ -31,7 +34,8 @@ namespace BotTidus.Services.FaceReactionCollector
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            using PeriodicTimer timer = new(TimeSpan.FromMinutes(1));
+            await Task.Delay(Delay, stoppingToken);
+            using PeriodicTimer timer = new(Interval);
 
             do
             {

--- a/src/BotTidus/Services/RecentMessageCollectingService.cs
+++ b/src/BotTidus/Services/RecentMessageCollectingService.cs
@@ -13,10 +13,12 @@ namespace BotTidus.Services
 
         protected Traq.ITraqApiClient Client { get; } = services.GetRequiredService<Traq.ITraqApiClient>();
 
+        public TimeSpan Delay { get; } = TimeSpan.FromSeconds(15);
         public TimeSpan Interval { get; } = interval.Duration();
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
+            await Task.Delay(Delay, stoppingToken);
             using PeriodicTimer timer = new(Interval);
             DateTimeOffset lastCollectedAt = DateTimeOffset.UtcNow;
 


### PR DESCRIPTION
- `RecentMessageCollectingService` と `FaceReactionCollectingService` の初回実行をヘルスチェック後に行うようにした.